### PR TITLE
Sort out build on Ubuntu 12.10

### DIFF
--- a/src/html-logger.c
+++ b/src/html-logger.c
@@ -108,7 +108,7 @@ static void html_log_log( const char* text,
 	if( text != NULL ) {
 		/* Write the text to the HTML file */
 		/* TODO: turn newlines into <br/> tags */
-		fprintf( hlog->html, text );
+		fputs( text, hlog->html );
 	}
 
 	fprintf( hlog->html, "</div>\n" );

--- a/src/text-logger.c
+++ b/src/text-logger.c
@@ -88,7 +88,7 @@ static void text_log_log( const char* text,
 	koki_text_logger_t* tlog = _logger;
 
 	if( text != NULL ) {
-		fprintf( tlog->f, text );
+		fputs( text, tlog->f );
 	}
 
 	if( img != NULL ) {


### PR DESCRIPTION
Fixes:
error: format not a string literal and no format arguments
[-Werror=format-security]

on Gcc 4.7.2
