### PR TITLE
Make it easy to link with C++

### DIFF
--- a/include/bearing.h
+++ b/include/bearing.h
@@ -25,9 +25,15 @@
 #include "points.h"
 #include "marker.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 koki_bearing_t koki_bearing_estimate_point(koki_point3Df_t point);
 
 void koki_bearing_estimate(koki_marker_t *marker);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_BEARING_H_ */

--- a/include/camera.h
+++ b/include/camera.h
@@ -26,6 +26,9 @@
 
 #include "points.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief a structure for camera related parameters
@@ -38,5 +41,8 @@ typedef struct {
 	koki_point2Di_t size;            /**< the dimensions of the image */
 } koki_camera_params_t;
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _KOKI_CAMERA_H_ */

--- a/include/code_grid.h
+++ b/include/code_grid.h
@@ -29,7 +29,9 @@
 #define KOKI_CODE_GRID_WIDTH 6
 #define KOKI_MARKER_GRID_WIDTH 10
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief a structure for counting and averaging an image of a marker into
  *        a grid
@@ -65,4 +67,7 @@ int16_t koki_code_recover_from_grid(koki_grid_t *grid, float *rotation_offset);
 
 int16_t koki_code_translation(int code);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_CODE_GRID_H_ */

--- a/include/context.h
+++ b/include/context.h
@@ -23,8 +23,11 @@
  */
 
 #include <glib.h>
-
 #include "logger.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief a libkoki context structure
@@ -43,5 +46,9 @@ void koki_destroy( koki_t* koki );
 void koki_log( koki_t* koki, const char* text, IplImage* img );
 
 gboolean koki_is_logging( koki_t* koki );
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif	/* _CONTEXT_H_ */

--- a/include/contour.h
+++ b/include/contour.h
@@ -27,11 +27,19 @@
 
 #include "labelling.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 GSList* koki_contour_find(koki_labelled_image_t *labelled_image,
 			       label_t region);
 
 void koki_contour_free(GSList *contour);
 
 void koki_contour_draw(IplImage *frame, GSList *contour);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _KOKI_CONTOUR_H_ */

--- a/include/debug.h
+++ b/include/debug.h
@@ -24,6 +24,10 @@
 
 #include <stdio.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define KOKI_DEBUG_NONE    0
 #define KOKI_DEBUG_SEVERE  1
 #define KOKI_DEBUG_ERROR   2
@@ -54,5 +58,9 @@
 		fprintf(KOKI_DEBUG_OUTPUT, "[%d]  ", level);		\
 		fprintf(KOKI_DEBUG_OUTPUT, __VA_ARGS__);		\
 	}
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _KOKI_DEBUG_H_ */

--- a/include/html-logger.h
+++ b/include/html-logger.h
@@ -29,6 +29,10 @@
 
 #include "logger.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	char* dpath;	/**< the path of the directory we're logging to */
 
@@ -42,4 +46,7 @@ void koki_html_logger_destroy( koki_html_logger_t* hlog );
 
 extern const logger_callbacks_t koki_html_logger_callbacks;
 
+#ifdef __cplusplus
+}
+#endif
 #endif	/* _HTML_LOGGER_H_ */

--- a/include/labelling.h
+++ b/include/labelling.h
@@ -30,6 +30,9 @@
 #include "context.h"
 #include "points.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define R 0
 #define G 1
@@ -150,4 +153,7 @@ koki_labelled_image_t* koki_label_adaptive( koki_t *koki,
 					    uint16_t window_size,
 					    int16_t thresh_margin );
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_LABELLING_H_ */

--- a/include/logger.h
+++ b/include/logger.h
@@ -24,6 +24,9 @@
 
 #include <cv.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief a structure to contain function pointers for a logger
   */
@@ -38,4 +41,7 @@ typedef struct {
 
 extern const logger_callbacks_t koki_null_logger;
 
+#ifdef __cplusplus
+}
+#endif
 #endif	/* _LOGGER_H_ */

--- a/include/marker.h
+++ b/include/marker.h
@@ -33,7 +33,9 @@
 
 #include "quad.h"
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief a structure representing a a single vertex, both in 2D and 3D space
  */
@@ -101,5 +103,7 @@ GPtrArray* koki_find_markers_fp( koki_t *koki,
 
 void koki_markers_free(GPtrArray *markers);
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_MARKER_H_ */

--- a/include/points.h
+++ b/include/points.h
@@ -24,6 +24,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief A structure for an integer-valued point in 2D space.
  */
@@ -53,4 +57,7 @@ typedef struct {
 	float z;  /**< the Z co-ordinate */
 } koki_point3Df_t;
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_POINTS_H_ */

--- a/include/pose.h
+++ b/include/pose.h
@@ -27,6 +27,10 @@
 #include "camera.h"
 #include "marker.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void koki_pose_estimate_arrays(koki_point2Df_t img[4],
 			       koki_point3Df_t world[4],
 			       float marker_width,
@@ -36,5 +40,8 @@ void koki_pose_estimate(koki_marker_t *marker,
 			float marker_width,
 			koki_camera_params_t *params);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _KOKI_POSE_H_ */

--- a/include/quad.h
+++ b/include/quad.h
@@ -27,6 +27,10 @@
 
 #include "points.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief a structure containing the links contour chain links and their
  *        respective points, for convinience.
@@ -49,4 +53,7 @@ void koki_quad_free(koki_quad_t *quad);
 
 void koki_quad_draw(IplImage *frame, koki_quad_t *quad);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_QUAD_H_ */

--- a/include/rotation.h
+++ b/include/rotation.h
@@ -25,9 +25,15 @@
 #include "points.h"
 #include "marker.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 koki_marker_rotation_t koki_rotation_estimate_array(koki_point3Df_t points[4]);
 
 void koki_rotation_estimate(koki_marker_t *marker);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_ROTATION_H_ */

--- a/include/text-logger.h
+++ b/include/text-logger.h
@@ -27,6 +27,10 @@
 
 #include "logger.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	FILE* f;     /**< the file that we're logging to */
 	gboolean close_on_destroy; /**< whether to close the file descriptor upon destruction  */
@@ -40,4 +44,7 @@ void koki_text_logger_destroy( koki_text_logger_t* tlog );
 
 extern const logger_callbacks_t koki_text_logger_callbacks;
 
+#ifdef __cplusplus
+}
+#endif
 #endif	/* _TEXT_LOGGER_H_ */

--- a/include/threshold.h
+++ b/include/threshold.h
@@ -27,9 +27,12 @@
 
 #include "integral-image.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define KOKI_ADAPTIVE_MEAN   1
 #define KOKI_ADAPTIVE_MEDIAN 2
-
 
 IplImage* koki_threshold_frame(IplImage *frame, uint16_t threshold);
 
@@ -48,4 +51,7 @@ void koki_threshold_adaptive_calc_window( const IplImage *frame,
 					  uint16_t width,
 					  uint16_t x, uint16_t y );
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_THRESHOLD_H_ */

--- a/include/unwarp.h
+++ b/include/unwarp.h
@@ -28,8 +28,13 @@
 #include "koki.h"
 #include "marker.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 IplImage* koki_unwarp_marker( koki_t* koki, koki_marker_t *marker, IplImage *frame,
 			      uint16_t unwarped_width );
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_UNWARP_H_ */

--- a/include/v4l.h
+++ b/include/v4l.h
@@ -26,6 +26,9 @@
 #include <linux/videodev2.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * @brief a structure for representing a memory-mapped buffer
  */
@@ -70,4 +73,7 @@ IplImage *koki_v4l_YUYV_frame_to_RGB_image(uint8_t *frame,
 IplImage *koki_v4l_YUYV_frame_to_grayscale_image(uint8_t *frame,
 						 uint16_t w, uint16_t h);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_V4L_H_ */

--- a/include/yaml_config.h
+++ b/include/yaml_config.h
@@ -26,8 +26,13 @@
 
 #include "camera.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 bool koki_cam_read_params(const char *filename, koki_camera_params_t *params);
 
-
+#ifdef __cplusplus
+}
+#endif
 #endif /* _KOKI_YAML_CONFIG_H_ */


### PR DESCRIPTION
Add a guarded extern "C" directive to all headers referenced from koki.h
to make it easier to link with them from C++ code.
